### PR TITLE
Adds cache utility function for data fetching

### DIFF
--- a/components/GrantList.tsx
+++ b/components/GrantList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Box, BoxProps, SimpleGrid } from '@chakra-ui/react'
 import { GrantItem } from '../components/GrantItem'
+import { getData } from '../utils'
 
 interface GrantListProps extends BoxProps {
   color?: string
@@ -11,8 +12,7 @@ export const GrantList: React.FC<GrantListProps> = ({ color }) => {
   const [data, setData] = useState([])
   useEffect(() => {
     ;(async () => {
-      const response = await fetch('./api/get_grants')
-      const data = await response.json()
+      const data: Array<{[key: string]: any}> = await getData('./api/get_grants')
       const maxHomepageItems = 10
       const mappedData = data
         .filter(

--- a/components/TwitterSection.tsx
+++ b/components/TwitterSection.tsx
@@ -2,6 +2,7 @@ import { Flex, BoxProps, Text, Image, Link } from "@chakra-ui/react"
 import { useState, useEffect } from "react"
 import { Section } from "./"
 import { TWITTER_HANDLE, BASE_TWEET_URL } from "../constants"
+import { getData } from "../utils"
 
 interface Annotation {
   start?: number
@@ -78,8 +79,7 @@ export const TwitterSection: React.FC<BoxProps> = (props) => {
   const [data, setData] = useState<Tweet[]>([]);
   useEffect(() => {
     ;(async () => {
-      const response = await fetch("api/tweets")
-      const data: Tweet[] = await response.json()
+      const data: Tweet[] = await getData("api/tweets")
       setData(data)
     })()
   }, [])

--- a/utils/cache.ts
+++ b/utils/cache.ts
@@ -1,0 +1,77 @@
+const ONE_HOUR = 1000 * 60 * 60
+
+export interface CacheStorage<T> {
+  value: T
+  timestamp: number
+}
+
+const emptyCacheItemStorage: CacheStorage<string> = {
+  value: "",
+  timestamp: 0,
+}
+
+const stringifyEmptyCacheItemStorage = JSON.stringify(emptyCacheItemStorage)
+
+/**
+ * Write inside the local storage the value returned by the API call for a given key
+ * @param {string} key stored in the local storage
+ * @param {T} value for a given key to write in the local storage
+ */
+export const writeToCache = <T>(key: string, value: T): void => {
+  const cacheStorageItem: CacheStorage<T> = {
+    value,
+    timestamp: new Date().getTime(),
+  }
+  localStorage.setItem(key, JSON.stringify(cacheStorageItem))
+}
+
+/**
+ * Retrieve the value stored in the local storage for a given key
+ * If the value is not defined or the key does not exist, return a default CacheStorage
+ * with an empty value and timestamp set to 0
+ * @see CacheStorage
+ * @param {string} key stored in the local storage
+ * @returns {CacheStorage<T>} element stored in browser local storage
+ */
+const readFromCache = <T>(key: string): CacheStorage<T> => {
+  return JSON.parse(
+    localStorage.getItem(key) || stringifyEmptyCacheItemStorage
+  ) as CacheStorage<T>
+}
+
+/**
+ * API call to get the response data and store in the local storage if needed
+ * @param {string} url API url
+ * @param {boolean} cacheResponse should we store the value to the local storage
+ * @returns {T} data response from the API
+ */
+export const getFreshData = async <T>(
+  url: string,
+  cacheResponse: boolean = false
+): Promise<T> => {
+  const response = await fetch(url)
+  const data: T = await response.json()
+  cacheResponse && writeToCache(url, data)
+  return data
+}
+
+const getCachedData = <T>(url: string): CacheStorage<T> => readFromCache(url)
+
+/**
+ * Get the data response from the local storage or the API
+ * @param {string} url of the API
+ * @returns {T} data from the API or the local storage
+ */
+export const getData = async <T>(url: string): Promise<T> => {
+  const cachedData: CacheStorage<T> = getCachedData(url)
+  const now = new Date().getTime()
+  if (
+    cachedData &&
+    cachedData.timestamp > 0 &&
+    now - cachedData.timestamp < ONE_HOUR
+  ) {
+    return cachedData.value
+  } else {
+    return getFreshData(url, true)
+  }
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./cache"


### PR DESCRIPTION
## Description
- Implements a `cache.ts` util to replace calling `fetch` directly
- Prevents repeat data fetching within one hour of already cached API responses

`import { getData } from '../utils'`

then use with `const data = await getData('api/path')`