### PR TITLE
Feat: add search filter for grant list

### DIFF
--- a/components/GrantItem.tsx
+++ b/components/GrantItem.tsx
@@ -1,7 +1,7 @@
-import { BoxProps, Button, Flex, Heading, HStack, Image, Text  } from '@chakra-ui/react'
+import { Flex, FlexProps, Heading, Text  } from '@chakra-ui/react'
 import { IconButtonLink, IconButton } from './'
 
-interface GrantItemProps extends BoxProps {
+interface GrantItemProps extends FlexProps {
   title: string
   date?: string
   url?: string

--- a/components/GrantList.tsx
+++ b/components/GrantList.tsx
@@ -8,7 +8,7 @@ interface GrantListProps extends BoxProps {
   color?: string
   filter?: string
 }
-export const GrantList: React.FC<GrantListProps> = ({ color, filter = '' }) => {
+export const GrantList: React.FC<GrantListProps> = ({ color, filter = '', ...props }) => {
   const { pathname } = useRouter()
   const [data, setData] = useState([])
   const [filteredData, setFilteredData] = useState([])
@@ -43,7 +43,7 @@ export const GrantList: React.FC<GrantListProps> = ({ color, filter = '' }) => {
     )
   }, [filter, data])
   return (
-    <Box w='100%'>
+    <Box w='100%' {...props}>
       <SimpleGrid columns={1}>
         {filteredData.map(({id, dateSubmitted, projectName, websiteUrl, amountAwarded }) => (
           <GrantItem 

--- a/pages/grants.tsx
+++ b/pages/grants.tsx
@@ -10,7 +10,7 @@ const Grants: FC = () => {
     <Flex flexDirection='column' w='100%'>
       <PageHero bg="brand.red">Grants</PageHero>
       <Section py={75}>
-        <Flex mx={{base: 6, xl: 0}}>
+        <Flex mx={{base: 6, xl: 0}} direction='column'>
           <Input
             placeholder="Search grant recipients"
             value={filter}
@@ -19,8 +19,8 @@ const Grants: FC = () => {
             color="bg"
             borderRadius='none'
           />
+          <GrantList filter={filter} color='brand.green' />
         </Flex>
-        <GrantList filter={filter} />
       </Section>
     </Flex>
   )


### PR DESCRIPTION
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/54227730/187086551-6c9f76cd-c803-416b-b89c-b9aeabdfed52.png">
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/54227730/187086584-93fce124-3895-4e0f-89cb-2f48225c0c2a.png">
Users can search to filter down grants list. Will match search string against the project name, url, date or amount received. 
Also fixes logic behind showing "DAI" next to the grant amount, only showing this if the value exists. This creates another small layout bug, will address separately. 