### PR TITLE
Add GitHub CODEOWNERS file

### DIFF
--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,0 +1,11 @@
+# This file defines the code owners of the repository
+# Code owners are automatically requested for review when someone opens a PR that modifies code that they own
+# Each line is a file pattern followed by one or more owners. 
+# Order is important; the last matching pattern takes the most precedence. Learn more here:
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @jonathanprozzi @wackerow
+
+# Owners of specific files


### PR DESCRIPTION
For when repo is made public, establishes branch protections and automatic requesting of reviews
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners