### PR TITLE
Fix: PhotoCarousel bug

### DIFF
--- a/components/PhotoCarousel.tsx
+++ b/components/PhotoCarousel.tsx
@@ -7,7 +7,7 @@ import { slickCss } from "../styles/slickCss"
 
 // Settings for the Slider component
 const settings = {
-  dots: true,
+  dots: false,
   arrows: false,
   fade: true,
   infinite: true,


### PR DESCRIPTION
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/54227730/188705085-8e7dabcf-cbcd-484f-ad77-d9991e1ce939.png">

Disabled "dots" option to fix this numbering bug. 